### PR TITLE
Automatic value range and log scale for Heatmap View

### DIFF
--- a/src/components/HeatmapCalendar/components/HeatmapGrid.tsx
+++ b/src/components/HeatmapCalendar/components/HeatmapGrid.tsx
@@ -45,6 +45,7 @@ type Props = {
   minValue?: number;
   maxValue?: number;
   overflowColor?: string;
+  logScale?: boolean;
   onEntryClick?: EntryClickEventHandler;
   rangeStartDate?: Date;
   rangeEndDate?: Date;
@@ -60,6 +61,7 @@ export const HeatmapGrid = ({
   minValue = 0,
   maxValue = 10,
   overflowColor,
+  logScale = false,
   onEntryClick,
   rangeStartDate,
   rangeEndDate,
@@ -107,6 +109,7 @@ export const HeatmapGrid = ({
               minValue={minValue}
               maxValue={maxValue}
               overflowColor={overflowColor}
+              logScale={logScale}
               onEntryClick={onEntryClick}
               rangeStartDate={rangeStartDate}
               rangeEndDate={rangeEndDate}

--- a/src/components/HeatmapCalendar/components/MonthGridView.tsx
+++ b/src/components/HeatmapCalendar/components/MonthGridView.tsx
@@ -41,6 +41,7 @@ type Props = {
 	minValue?: number;
 	maxValue?: number;
 	overflowColor?: string;
+	logScale?: boolean;
 	showDayLabels?: boolean;
 	layout?: "horizontal" | "vertical";
 	onEntryClick?: EntryClickEventHandler;
@@ -67,6 +68,7 @@ type DayCellProps = {
 	minValue: number;
 	maxValue: number;
 	overflowColor?: string;
+	logScale?: boolean;
 	onEntryClick?: EntryClickEventHandler;
 	rangeStartDate?: Date;
 	rangeEndDate?: Date;
@@ -82,6 +84,7 @@ const DayCell = memo(
 		minValue,
 		maxValue,
 		overflowColor,
+		logScale = false,
 		onEntryClick,
 		rangeStartDate,
 		rangeEndDate,
@@ -99,7 +102,7 @@ const DayCell = memo(
 		const occurrence = occurrenceMap.get(dateKey);
 		const count = occurrence?.count ?? 0;
 		const cellStyle = occurrence
-			? getCellStyle(count, classNames, minValue, maxValue, overflowColor)
+			? getCellStyle(count, classNames, minValue, maxValue, overflowColor, logScale)
 			: { className: classNames[0], isOverflow: false };
 
 		return (
@@ -132,6 +135,7 @@ const DayCell = memo(
 			prevProps.minValue === nextProps.minValue &&
 			prevProps.maxValue === nextProps.maxValue &&
 			prevProps.overflowColor === nextProps.overflowColor &&
+			prevProps.logScale === nextProps.logScale &&
 			prevProps.rangeStartDate?.getTime() === nextProps.rangeStartDate?.getTime() &&
 			prevProps.rangeEndDate?.getTime() === nextProps.rangeEndDate?.getTime() &&
 			prevProps.shape === nextProps.shape
@@ -150,6 +154,7 @@ type MonthBlockProps = {
 	minValue: number;
 	maxValue: number;
 	overflowColor?: string;
+	logScale?: boolean;
 	showDayLabels: boolean;
 	onEntryClick?: EntryClickEventHandler;
 	rangeStartDate?: Date;
@@ -167,6 +172,7 @@ const MonthBlock = memo(
 		minValue,
 		maxValue,
 		overflowColor,
+		logScale = false,
 		showDayLabels,
 		onEntryClick,
 		rangeStartDate,
@@ -206,6 +212,7 @@ const MonthBlock = memo(
 									minValue={minValue}
 									maxValue={maxValue}
 									overflowColor={overflowColor}
+									logScale={logScale}
 									onEntryClick={onEntryClick}
 									rangeStartDate={rangeStartDate}
 									rangeEndDate={rangeEndDate}
@@ -230,6 +237,7 @@ const MonthGridViewComponent = ({
 	minValue = 0,
 	maxValue = 10,
 	overflowColor,
+	logScale = false,
 	showDayLabels = true,
 	layout = "vertical",
 	onEntryClick,
@@ -303,6 +311,7 @@ const MonthGridViewComponent = ({
 					minValue={minValue}
 					maxValue={maxValue}
 					overflowColor={overflowColor}
+					logScale={logScale}
 					showDayLabels={showDayLabels}
 					onEntryClick={onEntryClick}
 					rangeStartDate={rangeStartDate}

--- a/src/components/HeatmapCalendar/components/WeekDay.tsx
+++ b/src/components/HeatmapCalendar/components/WeekDay.tsx
@@ -29,6 +29,7 @@ type Props = {
   minValue: number;
   maxValue: number;
   overflowColor?: string;
+  logScale?: boolean;
   onEntryClick?: EntryClickEventHandler;
   rangeStartDate?: Date;
   rangeEndDate?: Date;
@@ -42,6 +43,7 @@ const PureWeekDay = ({
   minValue,
   maxValue,
   overflowColor,
+  logScale = false,
   onEntryClick,
   rangeStartDate,
   rangeEndDate,
@@ -59,7 +61,7 @@ const PureWeekDay = ({
   const occurrence = occurrenceMap.get(dateKey);
   const count = occurrence?.count ?? 0;
   const cellStyle = occurrence
-    ? getCellStyle(count, classNames, minValue, maxValue, overflowColor)
+    ? getCellStyle(count, classNames, minValue, maxValue, overflowColor, logScale)
     : { className: classNames[0], isOverflow: false };
 
   return (
@@ -85,6 +87,7 @@ export const WeekDay = memo(PureWeekDay, (prevProps, nextProps) => {
     prevProps.minValue === nextProps.minValue &&
     prevProps.maxValue === nextProps.maxValue &&
     prevProps.overflowColor === nextProps.overflowColor &&
+    prevProps.logScale === nextProps.logScale &&
     prevProps.rangeStartDate?.getTime() === nextProps.rangeStartDate?.getTime() &&
     prevProps.rangeEndDate?.getTime() === nextProps.rangeEndDate?.getTime() &&
     prevProps.shape === nextProps.shape

--- a/src/components/HeatmapCalendar/index.tsx
+++ b/src/components/HeatmapCalendar/index.tsx
@@ -47,6 +47,7 @@ type Props = {
   minValue?: number;
   maxValue?: number;
   trackType?: TrackType;
+  logScale?: boolean;
   shape?: "circle" | "square" | "rounded";
   customColors?: string[];
   overflowColor?: string;
@@ -69,6 +70,7 @@ export const HeatmapCalendar = ({
   minValue,
   maxValue,
   trackType,
+  logScale = false,
   customColors,
   overflowColor,
   onEntryClick,
@@ -116,6 +118,7 @@ export const HeatmapCalendar = ({
           minValue={minValue}
           maxValue={maxValue}
           overflowColor={overflowColor}
+          logScale={logScale}
           showDayLabels={showDayLabels}
           layout={layout}
           onEntryClick={onEntryClick}
@@ -193,6 +196,7 @@ export const HeatmapCalendar = ({
                 minValue={minValue}
                 maxValue={maxValue}
                 overflowColor={overflowColor}
+                logScale={logScale}
                 onEntryClick={onEntryClick}
                 rangeStartDate={startDate}
                 rangeEndDate={endDate}
@@ -220,6 +224,7 @@ export const HeatmapCalendar = ({
                 minValue={minValue}
                 maxValue={maxValue}
                 overflowColor={overflowColor}
+                logScale={logScale}
                 onEntryClick={onEntryClick}
                 rangeStartDate={startDate}
                 rangeEndDate={endDate}

--- a/src/lib/i18n/locales/de.ts
+++ b/src/lib/i18n/locales/de.ts
@@ -295,8 +295,6 @@ export const de: LocaleTranslations = {
         },
         maxValue: {
           title: "Maximalwert",
-          manualEntry: "Maximalwert (Manuelle Eingabe)",
-          placeholder: "Maximalwert eingeben",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/de.ts
+++ b/src/lib/i18n/locales/de.ts
@@ -284,11 +284,19 @@ export const de: LocaleTranslations = {
       },
       valueRange: {
         title: "Wertebereich",
+        autoValueRange: {
+          title: "Automatischer Wertebereich",
+        },
+        logScale: {
+          title: "Logarithmische Skala",
+        },
         minValue: {
           title: "Minimalwert",
         },
         maxValue: {
           title: "Maximalwert",
+          manualEntry: "Maximalwert (Manuelle Eingabe)",
+          placeholder: "Maximalwert eingeben",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -282,11 +282,19 @@ export const en = {
       },
       valueRange: {
         title: "Value Range",
+        autoValueRange: {
+          title: "Auto Value Range",
+        },
+        logScale: {
+          title: "Log Scale",
+        },
         minValue: {
           title: "Min Value",
         },
         maxValue: {
           title: "Max Value",
+          manualEntry: "Max Value (Manual Entry)",
+          placeholder: "Enter max value",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -293,8 +293,6 @@ export const en = {
         },
         maxValue: {
           title: "Max Value",
-          manualEntry: "Max Value (Manual Entry)",
-          placeholder: "Enter max value",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -295,8 +295,6 @@ export const es: LocaleTranslations = {
         },
         maxValue: {
           title: "Valor Máximo",
-          manualEntry: "Valor Máximo (Entrada Manual)",
-          placeholder: "Ingrese el valor máximo",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/es.ts
+++ b/src/lib/i18n/locales/es.ts
@@ -284,11 +284,19 @@ export const es: LocaleTranslations = {
       },
       valueRange: {
         title: "Rango de Valores",
+        autoValueRange: {
+          title: "Rango de Valores Automático",
+        },
+        logScale: {
+          title: "Escala Logarítmica",
+        },
         minValue: {
           title: "Valor Mínimo",
         },
         maxValue: {
           title: "Valor Máximo",
+          manualEntry: "Valor Máximo (Entrada Manual)",
+          placeholder: "Ingrese el valor máximo",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/fr.ts
+++ b/src/lib/i18n/locales/fr.ts
@@ -284,11 +284,19 @@ export const fr: LocaleTranslations = {
       },
       valueRange: {
         title: "Plage de Valeurs",
+        autoValueRange: {
+          title: "Plage de Valeurs Automatique",
+        },
+        logScale: {
+          title: "Échelle Logarithmique",
+        },
         minValue: {
           title: "Valeur Minimale",
         },
         maxValue: {
           title: "Valeur Maximale",
+          manualEntry: "Valeur Maximale (Saisie Manuelle)",
+          placeholder: "Entrez la valeur maximale",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/fr.ts
+++ b/src/lib/i18n/locales/fr.ts
@@ -295,8 +295,6 @@ export const fr: LocaleTranslations = {
         },
         maxValue: {
           title: "Valeur Maximale",
-          manualEntry: "Valeur Maximale (Saisie Manuelle)",
-          placeholder: "Entrez la valeur maximale",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/it.ts
+++ b/src/lib/i18n/locales/it.ts
@@ -295,8 +295,6 @@ export const it: LocaleTranslations = {
         },
         maxValue: {
           title: "Valore Massimo",
-          manualEntry: "Valore Massimo (Inserimento Manuale)",
-          placeholder: "Inserisci il valore massimo",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/it.ts
+++ b/src/lib/i18n/locales/it.ts
@@ -284,11 +284,19 @@ export const it: LocaleTranslations = {
       },
       valueRange: {
         title: "Intervallo di Valori",
+        autoValueRange: {
+          title: "Intervallo di Valori Automatico",
+        },
+        logScale: {
+          title: "Scala Logaritmica",
+        },
         minValue: {
           title: "Valore Minimo",
         },
         maxValue: {
           title: "Valore Massimo",
+          manualEntry: "Valore Massimo (Inserimento Manuale)",
+          placeholder: "Inserisci il valore massimo",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -295,8 +295,6 @@ export const ja: LocaleTranslations = {
         },
         maxValue: {
           title: "最大値",
-          manualEntry: "最大値（手動入力）",
-          placeholder: "最大値を入力",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -284,11 +284,19 @@ export const ja: LocaleTranslations = {
       },
       valueRange: {
         title: "値の範囲",
+        autoValueRange: {
+          title: "自動値範囲",
+        },
+        logScale: {
+          title: "対数スケール",
+        },
         minValue: {
           title: "最小値",
         },
         maxValue: {
           title: "最大値",
+          manualEntry: "最大値（手動入力）",
+          placeholder: "最大値を入力",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/ko.ts
+++ b/src/lib/i18n/locales/ko.ts
@@ -284,11 +284,19 @@ export const ko: LocaleTranslations = {
       },
       valueRange: {
         title: "값 범위",
+        autoValueRange: {
+          title: "자동 값 범위",
+        },
+        logScale: {
+          title: "로그 스케일",
+        },
         minValue: {
           title: "최소값",
         },
         maxValue: {
           title: "최대값",
+          manualEntry: "최대값 (수동 입력)",
+          placeholder: "최대값 입력",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/ko.ts
+++ b/src/lib/i18n/locales/ko.ts
@@ -295,8 +295,6 @@ export const ko: LocaleTranslations = {
         },
         maxValue: {
           title: "최대값",
-          manualEntry: "최대값 (수동 입력)",
-          placeholder: "최대값 입력",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/pt.ts
+++ b/src/lib/i18n/locales/pt.ts
@@ -295,8 +295,6 @@ export const pt: LocaleTranslations = {
         },
         maxValue: {
           title: "Valor Máximo",
-          manualEntry: "Valor Máximo (Entrada Manual)",
-          placeholder: "Digite o valor máximo",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/pt.ts
+++ b/src/lib/i18n/locales/pt.ts
@@ -284,11 +284,19 @@ export const pt: LocaleTranslations = {
       },
       valueRange: {
         title: "Intervalo de Valores",
+        autoValueRange: {
+          title: "Intervalo de Valores Automático",
+        },
+        logScale: {
+          title: "Escala Logarítmica",
+        },
         minValue: {
           title: "Valor Mínimo",
         },
         maxValue: {
           title: "Valor Máximo",
+          manualEntry: "Valor Máximo (Entrada Manual)",
+          placeholder: "Digite o valor máximo",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/ru.ts
+++ b/src/lib/i18n/locales/ru.ts
@@ -284,11 +284,19 @@ export const ru: LocaleTranslations = {
       },
       valueRange: {
         title: "Диапазон Значений",
+        autoValueRange: {
+          title: "Автоматический Диапазон Значений",
+        },
+        logScale: {
+          title: "Логарифмическая Шкала",
+        },
         minValue: {
           title: "Минимальное Значение",
         },
         maxValue: {
           title: "Максимальное Значение",
+          manualEntry: "Максимальное Значение (Ручной Ввод)",
+          placeholder: "Введите максимальное значение",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/ru.ts
+++ b/src/lib/i18n/locales/ru.ts
@@ -295,8 +295,6 @@ export const ru: LocaleTranslations = {
         },
         maxValue: {
           title: "Максимальное Значение",
-          manualEntry: "Максимальное Значение (Ручной Ввод)",
-          placeholder: "Введите максимальное значение",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -295,8 +295,6 @@ export const zh: LocaleTranslations = {
         },
         maxValue: {
           title: "最大值",
-          manualEntry: "最大值（手动输入）",
-          placeholder: "输入最大值",
         },
       },
       appearance: {

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -284,11 +284,19 @@ export const zh: LocaleTranslations = {
       },
       valueRange: {
         title: "值范围",
+        autoValueRange: {
+          title: "自动值范围",
+        },
+        logScale: {
+          title: "对数刻度",
+        },
         minValue: {
           title: "最小值",
         },
         maxValue: {
           title: "最大值",
+          manualEntry: "最大值（手动输入）",
+          placeholder: "输入最大值",
         },
       },
       appearance: {

--- a/src/views/HeatmapCalendar/constants.ts
+++ b/src/views/HeatmapCalendar/constants.ts
@@ -22,6 +22,8 @@ export const DEFAULTS: HeatmapCalendarConfig = {
   showYearLabels: false,
   showLegend: true,
   /* Value Range */
+  autoValueRange: false,
+  logScale: false,
   minValue: 0,
   maxValue: 10,
   /* Appearance */
@@ -139,6 +141,18 @@ export const HEATMAP_CALENDAR_OPTIONS: ViewOption[] = [
     displayName: t("options.valueRange.title"),
     items: [
       {
+        type: "toggle",
+        displayName: t("options.valueRange.autoValueRange.title"),
+        key: "autoValueRange",
+        default: DEFAULTS.autoValueRange,
+      },
+      {
+        type: "toggle",
+        displayName: t("options.valueRange.logScale.title"),
+        key: "logScale",
+        default: DEFAULTS.logScale,
+      },
+      {
         type: "slider",
         displayName: t("options.valueRange.minValue.title"),
         key: "minValue",
@@ -146,6 +160,7 @@ export const HEATMAP_CALENDAR_OPTIONS: ViewOption[] = [
         min: 0,
         max: 100,
         step: 1,
+        shouldHide: (config) => config.get("autoValueRange") === true,
       },
       {
         type: "slider",
@@ -155,6 +170,7 @@ export const HEATMAP_CALENDAR_OPTIONS: ViewOption[] = [
         min: 0,
         max: 100,
         step: 1,
+        shouldHide: (config) => config.get("autoValueRange") === true,
       },
     ],
   },

--- a/src/views/HeatmapCalendar/types.ts
+++ b/src/views/HeatmapCalendar/types.ts
@@ -18,6 +18,8 @@ export type HeatmapCalendarConfig = {
   showMonthLabels?: boolean;
   showYearLabels?: boolean;
   showLegend?: boolean;
+  autoValueRange?: boolean;
+  logScale?: boolean;
   minValue?: number;
   maxValue?: number;
   trackType?: TrackType;


### PR DESCRIPTION
I am not sure you are interested in this but when tracking numerical values a max range of 100 can be limiting, for instance when tracking file size. The log scale makes sure the values stay within a sensible range even when there are outliers.